### PR TITLE
Add simple confidence averaging strategy

### DIFF
--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -33,7 +33,6 @@ class TestWBF(unittest.TestCase):
             conf_type='weighted_avg'
         )
 
-        print(type(boxes))
         ## test for bbox
 
         # bbox with score = 0.95 (no overlap)

--- a/tests/test_bbox.py
+++ b/tests/test_bbox.py
@@ -1,0 +1,72 @@
+import unittest
+import numpy as np
+from ensemble_boxes import *
+
+
+class TestWBF(unittest.TestCase):
+    def test_weighted_avg(self):
+        boxes_list = [
+            [
+                [0.1, 0.1, 0.5, 0.5],
+                [0.2, 0.2, 0.5, 0.5],
+                [0.45, 0.45, 0.5, 0.5],
+            ],
+            [
+                [0.3, 0.3, 0.6, 0.6],
+                [0.8, 0.8, 0.9, 0.9],
+            ],
+        ]
+
+        scores_list = [[0.9, 0.7, 0.2], [0.5, 0.95]]
+        labels_list = [[1, 1, 1], [1, 0]]
+        weights = [2, 1]
+        iou_thr = 0.5
+        skip_box_thr = 0.0001
+
+        boxes, scores, labels = weighted_boxes_fusion(
+            boxes_list,
+            scores_list,
+            labels_list,
+            weights=weights,
+            iou_thr=iou_thr,
+            skip_box_thr=skip_box_thr,
+            conf_type='weighted_avg'
+        )
+
+        print(type(boxes))
+        ## test for bbox
+
+        # bbox with score = 0.95 (no overlap)
+        np.testing.assert_allclose(boxes[0], [0.8, 0.8, 0.9, 0.9])
+
+        # bbox with score = 0.9 and 0.7 (overlapped)
+        # x1 (or y1) = (0.9 * 0.1 + 0.7 * 0.2) / (0.9 + 0.7) = 0.14375
+        # x2 (or y2) = (0.9 * 0.5 + 0.7 * 0.5) / (0.9 + 0.7) = 0.5
+        np.testing.assert_allclose(boxes[1], [0.14375, 0.14375, 0.5, 0.5])
+
+        # bbox with score = 0.5 (no overlap)
+        np.testing.assert_allclose(boxes[2], [0.3, 0.3, 0.6, 0.6])
+
+        # bbox with score = 0.2 (no overlap)
+        np.testing.assert_allclose(boxes[3], [0.45, 0.45, 0.5, 0.5])
+
+        ## test for scores
+
+        # no overlap
+        np.testing.assert_allclose(scores[0], 0.95)
+
+        # overlap 0.9 and 0.7
+        # (2 * 0.9 + 2 * 0.7) / (2 + 2) = 0.8
+        np.testing.assert_allclose(scores[1], 0.8)
+
+        # no overlap
+        np.testing.assert_allclose(scores[2], 0.5)
+
+        # no overlap
+        np.testing.assert_allclose(scores[3], 0.2)
+
+        ## test for labels
+        np.testing.assert_array_equal(labels, [0, 1, 1, 1])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi, @ZFTurbo. 
Now, I'm reading your paper and this repo, and I might identify the cause of the issue discussed in #10.
I am describing what a cause is in the following sections.

To fix this issue, I made a PR that proposes another conf_type.
Note that this modification can change confidence score, but not any bbox coordinates.

I'm not an expert, so I may have missed something important. If so, please feel free to point it out.
I appreciate it if you review this, and I hope this PR will contribute to the community.

## Problem

The `weighted_boxes_fusion` can return confidence score larger than 1.0 regardless of the `allows_overflow` parameter.

This is a reproducable example.

```py
from ensemble_boxes import *

boxes_list = [[
    [0.1, 0.1, 0.2, 0.2],
    [0.1, 0.1, 0.2, 0.2],
    
],[
    [0.3, 0.3, 0.4, 0.4],
]]
scores_list = [[1.0, 1.0], [0.5]]
labels_list = [[0, 0], [0]]
weights = [2, 1]

iou_thr = 0.5
skip_box_thr = 0.0001
sigma = 0.1

boxes, scores, labels = weighted_boxes_fusion(boxes_list, scores_list, labels_list, weights=weights, iou_thr=iou_thr, skip_box_thr=skip_box_thr, allows_overflow=True)
print(scores)
# [1.33333337 0.16666667]

boxes, scores, labels = weighted_boxes_fusion(boxes_list, scores_list, labels_list, weights=weights, iou_thr=iou_thr, skip_box_thr=skip_box_thr, allows_overflow=False)
print(scores)
# [1.33333337 0.16666667]
```

## Why?

According to the paper^[1], the confidence score is given by the eq.(1) and (5). Combining the two equations, we can get the following equation.

<a href="https://www.codecogs.com/eqnedit.php?latex=\dpi{120}&space;C&space;=&space;\frac{\sum_i^TC_i}{T}&space;\frac{min(W,&space;T))}{W}." target="_blank"><img src="https://latex.codecogs.com/gif.latex?\dpi{120}&space;C&space;=&space;\frac{\sum_i^TC_i}{T}&space;\frac{min(W,&space;T))}{W}." title="C = \frac{\sum_i^TC_i}{T} \frac{min(W, T))}{W}." /></a>

```latex
C = \frac{\sum_i^TC_i}{T} \frac{min(W, T))}{W}.
```

Since the current implementation has taken into account the weights, we should rewrite the equation.
If we expand `min(...)` part explicitly, the resulting equation looks like this:

<a href="https://www.codecogs.com/eqnedit.php?latex=\dpi{120}&space;\begin{align*}&space;C&space;&=&space;\frac{\sum_i^T&space;w_i&space;C_i}{T}&space;\frac{min(W,&space;T))}{W},&space;\\&space;&=&space;\begin{cases}&space;\frac{\sum_i^T&space;w_i&space;c_i}{T},&space;&&space;W&space;\le&space;T&space;\\&space;\frac{\sum_i^T&space;w_i&space;c_i}{W},&space;&&space;W&space;>&space;T&space;\end{cases}&space;\end{align*}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\dpi{120}&space;\begin{align*}&space;C&space;&=&space;\frac{\sum_i^T&space;w_i&space;C_i}{T}&space;\frac{min(W,&space;T))}{W},&space;\\&space;&=&space;\begin{cases}&space;\frac{\sum_i^T&space;w_i&space;c_i}{T},&space;&&space;W&space;\le&space;T&space;\\&space;\frac{\sum_i^T&space;w_i&space;c_i}{W},&space;&&space;W&space;>&space;T&space;\end{cases}&space;\end{align*}" title="\begin{align*} C &= \frac{\sum_i^T w_i C_i}{T} \frac{min(W, T))}{W}, \\ &= \begin{cases} \frac{\sum_i^T w_i c_i}{T}, & W \le T \\ \frac{\sum_i^T w_i c_i}{W}, & W > T \end{cases} \end{align*}" /></a>

```latex
\begin{align*}
C &= \frac{\sum_i^T w_i C_i}{T} \frac{min(W, T))}{W}, \\
  &= \begin{cases} 
        \frac{\sum_i^T w_i c_i}{T}, & W \le T \\
        \frac{\sum_i^T w_i c_i}{W}, & W > T
     \end{cases}
\end{align*},
```

where the `w_i` is a weight per box, and the `W` denotes the total weights over the models (`weight.sum()`).

The last equation implies that the result is unbounded if w_i's are not unbounded.
In the above case, we can calculate `C = 2*1 + 2*1 / 3 = 1.33..., (W = 3, T = 2)`.
This is why the result can be larger than 1.0.

## A proposal to fix

In this PR, I propose the following simple weighted average.

<a href="https://www.codecogs.com/eqnedit.php?latex=\dpi{120}&space;C&space;=&space;\frac{\sum_i^Tw_iC_i}{\sum_i^T{w_i}}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\dpi{120}&space;C&space;=&space;\frac{\sum_i^Tw_iC_i}{\sum_i^T{w_i}}" title="C = \frac{\sum_i^Tw_iC_i}{\sum_i^T{w_i}}" /></a>

```latex
C = \frac{\sum_i^Tw_iC_i}{\sum_i^T{w_i}} 
```

Note that the denominator is a weights sum over the boxes of a cluster (not over the models `weight.sum()`).
Apparently, this is bounded in [0, 1] if the input scores are bounded in [0, 1].

Note that using the normalized weight (to make sure `weight.sum == 1`) does not fix the issue. 
If you use normalized weight, the resulting scores will be underestimated by dividing `T` or `W`.

This is a `weighted_avg` version example.
```
boxes_list = [[
    [0.1, 0.1, 0.2, 0.2],
    [0.1, 0.1, 0.2, 0.2],
    
],[
    [0.3, 0.3, 0.4, 0.4],
]]
scores_list = [[1.0, 1.0], [0.5]]
labels_list = [[0, 0], [0]]
weights = [2, 1]

iou_thr = 0.5
skip_box_thr = 0.0001
sigma = 0.1

boxes, scores, labels = weighted_boxes_fusion(boxes_list, scores_list, labels_list, weights=weights, iou_thr=iou_thr, skip_box_thr=skip_box_thr, allows_overflow=False, conf_type='weighted_avg')
print(scores)
# [1.  0.5]

## use other scores
scores_list = [[0.8, 1.0], [0.5]]
boxes, scores, labels = weighted_boxes_fusion(boxes_list, scores_list, labels_list, weights=weights, iou_thr=iou_thr, skip_box_thr=skip_box_thr, allows_overflow=False, conf_type='weighted_avg')
print(scores)
# [0.89999998 0.5]
```

## Performance

Sorry, I did not conduct any performance experiments.
So, I have no idea how much of an impact this fix will have on performance at this point.


[1] https://arxiv.org/abs/1910.13302